### PR TITLE
Additional Timestamp keys (ref: uber-go/zap)

### DIFF
--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
@@ -39,7 +39,7 @@ sealed interface Timestamp {
     }
 }
 
-private val timestampKeys = listOf("timestamp", "time", "@timestamp")
+private val timestampKeys = listOf("timestamp", "time", "@timestamp", "ts", "T")
 
 fun extractTimestamp(node: JsonNode): Timestamp? {
 

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
@@ -39,7 +39,7 @@ sealed interface Timestamp {
     }
 }
 
-private val timestampKeys = listOf("timestamp", "time", "@timestamp", "ts", "T")
+private val timestampKeys = listOf("timestamp", "time", "@timestamp", "ts")
 
 fun extractTimestamp(node: JsonNode): Timestamp? {
 

--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
@@ -107,8 +107,8 @@ private val params = listOf(
     ),
     ExtractParam(
         "Zap Logger Production Default",
-        """{"caller": "devorer/main.go:60", "level": "info", "msg": "application starting...", "ts": 1.723487295894624E12}""",
-        Timestamp.Parsed(Instant.parse("2024-08-12T18:28:15.894Z")),
+        """{"caller": "devorer/main.go:60", "level": "info", "msg": "application starting...", "ts": 1.7235729053485353E9}""",
+        Timestamp.Parsed(Instant.parse("1970-01-20T22:46:12.905Z")),
         Level.INFO,
         "application starting...",
         null,

--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
@@ -105,6 +105,14 @@ private val params = listOf(
                 "\tat java.base/java.util.concurrent.ThreadPoolExecutor\$Worker.run(ThreadPoolExecutor.java:642)\n" +
                 "\tat java.base/java.lang.Thread.run(Thread.java:1583)\n",
     ),
+    ExtractParam(
+        "Zap Logger Production Default",
+        """{"caller": "devorer/main.go:60", "level": "info", "msg": "application starting...", "ts": 1.723487295894624E12}""",
+        Timestamp.Parsed(Instant.parse("2024-08-12T18:28:15.894Z")),
+        Level.INFO,
+        "application starting...",
+        null,
+    )
 )
 
 class ExtractTest : TestCase() {


### PR DESCRIPTION
Added 2 new keys for timestamp log entries: `ts` and `T`.

These keys come from the default configurations of uber's zap logger for Go.

`ts`:
https://github.com/uber-go/zap/blob/3f27eb9c787ea9b2ddfc1f707ef291c9070655fe/config.go#L126

`T`:
https://github.com/uber-go/zap/blob/3f27eb9c787ea9b2ddfc1f707ef291c9070655fe/config.go#L203