### PR TITLE
Detect epoch precision automatically

### DIFF
--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
@@ -108,7 +108,7 @@ private val params = listOf(
     ExtractParam(
         "Zap Logger Production Default",
         """{"caller": "devorer/main.go:60", "level": "info", "msg": "application starting...", "ts": 1.7235729053485353E9}""",
-        Timestamp.Parsed(Instant.parse("1970-01-20T22:46:12.905Z")),
+        Timestamp.Parsed(Instant.parse("2024-08-13T18:15:05Z")),
         Level.INFO,
         "application starting...",
         null,

--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/TimestampTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/TimestampTest.kt
@@ -1,0 +1,39 @@
+package io.github.orangain.prettyjsonlog.logentry
+
+import junit.framework.TestCase
+import java.time.Instant
+
+private val testCases: List<Pair<Long, String>> = listOf(
+    // seconds
+    0L to "1970-01-01T00:00:00Z",
+    1L to "1970-01-01T00:00:01Z",
+    1000L to "1970-01-01T00:16:40Z",
+    1000000000L to "2001-09-09T01:46:40Z",
+    1000000001L to "2001-09-09T01:46:41Z",
+    1723644284L to "2024-08-14T14:04:44Z",
+    9999999999L to "2286-11-20T17:46:39Z",
+    // milliseconds
+    10000000000L to "1970-04-26T17:46:40Z",
+    10000000001L to "1970-04-26T17:46:40.001Z",
+    1723644284001L to "2024-08-14T14:04:44.001Z",
+    9999999999999L to "2286-11-20T17:46:39.999Z",
+    // microseconds
+    10000000000000L to "1970-04-26T17:46:40Z",
+    10000000000001L to "1970-04-26T17:46:40.000001Z",
+    1723644284000001L to "2024-08-14T14:04:44.000001Z",
+    9999999999999999L to "2286-11-20T17:46:39.999999Z",
+    // nanoseconds
+    10000000000000000L to "1970-04-26T17:46:40Z",
+    10000000000000001L to "1970-04-26T17:46:40.000000001Z",
+    1723644284000000001L to "2024-08-14T14:04:44.000000001Z",
+    9223372036854775807L to "2262-04-11T23:47:16.854775807Z", // Long.MAX_VALUE
+)
+
+class TimestampTest : TestCase() {
+    fun testFromEpoch() {
+        testCases.forEach { (input, expected) ->
+            val actual = Timestamp.fromEpoch(input)
+            assertEquals("Timestamp.fromEpoch($input)", Timestamp.Parsed(Instant.parse(expected)), actual)
+        }
+    }
+}


### PR DESCRIPTION
Previously, unix timestamp is considered as milliseconds, but some library uses seconds. This PR enable the plugin to detect epoch precision automatically.

See: https://github.com/orangain/pretty-json-log-plugin/pull/54#issuecomment-2284685997