### PR TITLE
Add support for Serilog

### DIFF
--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Level.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Level.kt
@@ -39,7 +39,7 @@ enum class Level {
     }
 }
 
-private val levelKeys = listOf("level", "severity", "log.level", "@l")
+private val levelKeys = listOf("level", "severity", "log.level", "@l", "Level")
 
 fun extractLevel(node: JsonNode): Level? {
     return levelKeys.firstNotNullOfOrNull { node.get(it) }?.let { levelNode ->

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Level.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Level.kt
@@ -39,7 +39,7 @@ enum class Level {
     }
 }
 
-private val levelKeys = listOf("level", "severity", "log.level")
+private val levelKeys = listOf("level", "severity", "log.level", "@l")
 
 fun extractLevel(node: JsonNode): Level? {
     return levelKeys.firstNotNullOfOrNull { node.get(it) }?.let { levelNode ->

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Message.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Message.kt
@@ -2,7 +2,7 @@ package io.github.orangain.prettyjsonlog.logentry
 
 import com.fasterxml.jackson.databind.JsonNode
 
-private val messageKeys = listOf("message", "msg", "error.message")
+private val messageKeys = listOf("message", "msg", "error.message", "@m")
 
 fun extractMessage(node: JsonNode): String? {
     return messageKeys.firstNotNullOfOrNull { node.get(it) }?.asText()

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Message.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Message.kt
@@ -2,7 +2,7 @@ package io.github.orangain.prettyjsonlog.logentry
 
 import com.fasterxml.jackson.databind.JsonNode
 
-private val messageKeys = listOf("message", "msg", "error.message", "@m")
+private val messageKeys = listOf("message", "msg", "error.message", "@m", "RenderedMessage")
 
 fun extractMessage(node: JsonNode): String? {
     return messageKeys.firstNotNullOfOrNull { node.get(it) }?.asText()

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/StackTrace.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/StackTrace.kt
@@ -7,6 +7,7 @@ private val stackTraceNodeExtractors: List<NodeExtractor> = listOf(
     { it.get("exception") },
     { it.get("error.stack_trace") },
     { it.get("err")?.get("stack") },
+    { it.get("@x") },
 )
 
 fun extractStackTrace(node: JsonNode): String? {

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/StackTrace.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/StackTrace.kt
@@ -8,6 +8,7 @@ private val stackTraceNodeExtractors: List<NodeExtractor> = listOf(
     { it.get("error.stack_trace") },
     { it.get("err")?.get("stack") },
     { it.get("@x") },
+    { it.get("Exception") },
 )
 
 fun extractStackTrace(node: JsonNode): String? {

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
@@ -49,7 +49,7 @@ sealed interface Timestamp {
     }
 }
 
-private val timestampKeys = listOf("timestamp", "time", "@timestamp", "ts")
+private val timestampKeys = listOf("timestamp", "time", "@timestamp", "ts", "@t")
 
 fun extractTimestamp(node: JsonNode): Timestamp? {
 

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
@@ -49,7 +49,7 @@ sealed interface Timestamp {
     }
 }
 
-private val timestampKeys = listOf("timestamp", "time", "@timestamp", "ts", "@t")
+private val timestampKeys = listOf("timestamp", "time", "@timestamp", "ts", "@t", "Timestamp")
 
 fun extractTimestamp(node: JsonNode): Timestamp? {
 

--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
@@ -126,6 +126,18 @@ private val params = listOf(
                at Program.<Main>${'$'}(String[] args) in /Users/orange/RiderProjects/ConsoleApp1/ConsoleApp1/Program.cs:line 19
         """.trimIndent(),
     ),
+    // https://github.com/serilog/serilog/blob/main/src/Serilog/Formatting/Json/JsonFormatter.cs
+    ExtractParam(
+        "Serilog Rendered JSON",
+        """{"Timestamp":"2024-09-07T15:48:19.6174980+09:00","Level":"Error","MessageTemplate":"Unhandled exception","RenderedMessage":"Unhandled exception","Exception":"System.InvalidOperationException: Oops...\n   at Program.<Main>${'$'}(String[] args) in /Users/orange/RiderProjects/ConsoleApp1/ConsoleApp1/Program.cs:line 19"}""",
+        Timestamp.Parsed(Instant.parse("2024-09-07T06:48:19.617498Z")),
+        Level.ERROR,
+        "Unhandled exception",
+        """
+            System.InvalidOperationException: Oops...
+               at Program.<Main>${'$'}(String[] args) in /Users/orange/RiderProjects/ConsoleApp1/ConsoleApp1/Program.cs:line 19
+        """.trimIndent(),
+    ),
 )
 
 class ExtractTest : TestCase() {

--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
@@ -105,6 +105,7 @@ private val params = listOf(
                 "\tat java.base/java.util.concurrent.ThreadPoolExecutor\$Worker.run(ThreadPoolExecutor.java:642)\n" +
                 "\tat java.base/java.lang.Thread.run(Thread.java:1583)\n",
     ),
+    // https://pkg.go.dev/go.uber.org/zap
     ExtractParam(
         "Zap Logger Production Default",
         """{"caller": "devorer/main.go:60", "level": "info", "msg": "application starting...", "ts": 1.7235729053485353E9}""",

--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
@@ -113,7 +113,19 @@ private val params = listOf(
         Level.INFO,
         "application starting...",
         null,
-    )
+    ),
+    // https://github.com/serilog/serilog-formatting-compact?tab=readme-ov-file#format-details
+    ExtractParam(
+        "Serilog Rendered Compact JSON",
+        """{"@t":"2024-09-07T03:50:13.7292340Z","@m":"Unhandled exception","@i":"f80f533c","@l":"Error","@x":"System.InvalidOperationException: Oops...\n   at Program.<Main>${'$'}(String[] args) in /Users/orange/RiderProjects/ConsoleApp1/ConsoleApp1/Program.cs:line 19"}""",
+        Timestamp.Parsed(Instant.parse("2024-09-07T03:50:13.7292340Z")),
+        Level.ERROR,
+        "Unhandled exception",
+        """
+            System.InvalidOperationException: Oops...
+               at Program.<Main>${'$'}(String[] args) in /Users/orange/RiderProjects/ConsoleApp1/ConsoleApp1/Program.cs:line 19
+        """.trimIndent(),
+    ),
 )
 
 class ExtractTest : TestCase() {


### PR DESCRIPTION
This pr fixes #53.

Note that this includes support for the rendered-version of the formatters in Serilog. Message templates are not supported yet.