### PR TITLE
Add context menu to temporarily disable formatting

### DIFF
--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/action/ToggleEnabledAction.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/action/ToggleEnabledAction.kt
@@ -1,0 +1,25 @@
+package io.github.orangain.prettyjsonlog.action
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.LangDataKeys
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.DumbAwareToggleAction
+import io.github.orangain.prettyjsonlog.service.EphemeralStateService
+
+class ToggleEnabledAction : DumbAwareToggleAction() {
+    override fun isSelected(e: AnActionEvent): Boolean {
+        val consoleView = e.getData(LangDataKeys.CONSOLE_VIEW) ?: return false
+        val project = e.project ?: return false
+        val service = project.service<EphemeralStateService>()
+        return service.isEnabled(consoleView)
+    }
+
+    override fun setSelected(e: AnActionEvent, state: Boolean) {
+        thisLogger().debug("setSelected: $state")
+        val consoleView = e.getData(LangDataKeys.CONSOLE_VIEW) ?: return
+        val project = e.project ?: return
+        val service = project.service<EphemeralStateService>()
+        service.setEnabled(consoleView, state)
+    }
+}

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleFolding.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleFolding.kt
@@ -24,6 +24,8 @@ class MyConsoleFolding : ConsoleFolding() {
     }
 
     override fun isEnabledForConsole(consoleView: ConsoleView): Boolean {
+        // This method "isEnabledForConsole" is not for storing consoleView, but we use it for that purpose because
+        // there is no other way to get consoleView reference in "shouldFoldLine" method.
         this.consoleView = consoleView
         return true
     }

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleFolding.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleFolding.kt
@@ -1,18 +1,37 @@
 package io.github.orangain.prettyjsonlog.console
 
 import com.intellij.execution.ConsoleFolding
+import com.intellij.execution.ui.ConsoleView
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import io.github.orangain.prettyjsonlog.json.isPartOfPrettyJson
+import io.github.orangain.prettyjsonlog.service.EphemeralStateService
 
 class MyConsoleFolding : ConsoleFolding() {
+    private var consoleView: ConsoleView? = null
+
     override fun getPlaceholderText(project: Project, lines: List<String>): String {
         return "{...}"
     }
 
     override fun shouldFoldLine(project: Project, line: String): Boolean {
         thisLogger().debug("shouldFoldLine: $line")
+        if (!isEnabled(project)) {
+            return false
+        }
         return isPartOfPrettyJson(line)
+    }
+
+    override fun isEnabledForConsole(consoleView: ConsoleView): Boolean {
+        this.consoleView = consoleView
+        return true
+    }
+
+    private fun isEnabled(project: Project): Boolean {
+        val service = project.service<EphemeralStateService>()
+        val consoleView = this.consoleView ?: return false
+        return service.isEnabled(consoleView)
     }
 
 //    override fun shouldBeAttachedToThePreviousLine(): Boolean {

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleInputFilterProvider.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleInputFilterProvider.kt
@@ -4,6 +4,7 @@ import com.intellij.execution.filters.ConsoleDependentInputFilterProvider
 import com.intellij.execution.filters.InputFilter
 import com.intellij.execution.ui.ConsoleView
 import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Pair
@@ -11,6 +12,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import io.github.orangain.prettyjsonlog.json.parseJson
 import io.github.orangain.prettyjsonlog.json.prettyPrintJson
 import io.github.orangain.prettyjsonlog.logentry.*
+import io.github.orangain.prettyjsonlog.service.EphemeralStateService
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
@@ -60,6 +62,11 @@ class MyConsoleInputFilter(
                 contentType
             ),
         )
+    }
+
+    private fun isEnabled(): Boolean {
+        val service = project.service<EphemeralStateService>()
+        return service.isEnabled(consoleView)
     }
 }
 

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleInputFilterProvider.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleInputFilterProvider.kt
@@ -16,6 +16,8 @@ import io.github.orangain.prettyjsonlog.service.EphemeralStateService
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
+// We use ConsoleDependentInputFilterProvider instead of ConsoleInputFilterProvider because we need to access
+// ConsoleView and Project in the filter.
 class MyConsoleInputFilterProvider : ConsoleDependentInputFilterProvider() {
     override fun getDefaultFilters(
         consoleView: ConsoleView,

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleInputFilterProvider.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleInputFilterProvider.kt
@@ -1,33 +1,45 @@
 package io.github.orangain.prettyjsonlog.console
 
-import com.intellij.execution.filters.ConsoleInputFilterProvider
+import com.intellij.execution.filters.ConsoleDependentInputFilterProvider
 import com.intellij.execution.filters.InputFilter
+import com.intellij.execution.ui.ConsoleView
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Pair
+import com.intellij.psi.search.GlobalSearchScope
 import io.github.orangain.prettyjsonlog.json.parseJson
 import io.github.orangain.prettyjsonlog.json.prettyPrintJson
 import io.github.orangain.prettyjsonlog.logentry.*
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-class MyConsoleInputFilterProvider : ConsoleInputFilterProvider {
-    override fun getDefaultFilters(project: Project): Array<InputFilter> {
+class MyConsoleInputFilterProvider : ConsoleDependentInputFilterProvider() {
+    override fun getDefaultFilters(
+        consoleView: ConsoleView,
+        project: Project,
+        scope: GlobalSearchScope
+    ): MutableList<InputFilter> {
         thisLogger().debug("getDefaultFilters")
-        return arrayOf(MyConsoleInputFilter())
+        return mutableListOf(MyConsoleInputFilter(consoleView, project))
     }
 }
 
 private val zoneId = ZoneId.systemDefault()
 private val timestampFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
 
-class MyConsoleInputFilter : InputFilter {
+class MyConsoleInputFilter(
+    private val consoleView: ConsoleView,
+    private val project: Project
+) : InputFilter {
     override fun applyFilter(
         text: String,
         contentType: ConsoleViewContentType
     ): MutableList<Pair<String, ConsoleViewContentType>>? {
         thisLogger().debug("contentType: $contentType, applyFilter: $text")
+        if (!isEnabled()) {
+            return null
+        }
         val (node, suffixWhitespaces) = parseJson(text) ?: return null
 
         val timestamp = extractTimestamp(node)

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/service/EphemeralStateService.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/service/EphemeralStateService.kt
@@ -1,0 +1,24 @@
+package io.github.orangain.prettyjsonlog.service
+
+import com.intellij.execution.ui.ConsoleView
+import com.intellij.openapi.components.Service
+import java.util.*
+
+@Service(Service.Level.PROJECT)
+class EphemeralStateService {
+    private val enabledMap = WeakHashMap<ConsoleView, Boolean>()
+
+    /**
+     * Returns true if the filter is enabled for the given console view.
+     */
+    fun isEnabled(consoleView: ConsoleView): Boolean {
+        return enabledMap[consoleView] ?: true
+    }
+
+    /**
+     * Sets the enabled state for the given console view.
+     */
+    fun setEnabled(consoleView: ConsoleView, value: Boolean) {
+        enabledMap[consoleView] = value
+    }
+}

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/service/EphemeralStateService.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/service/EphemeralStateService.kt
@@ -9,14 +9,14 @@ class EphemeralStateService {
     private val enabledMap = WeakHashMap<ConsoleView, Boolean>()
 
     /**
-     * Returns true if the filter is enabled for the given console view.
+     * Returns true if the formatting is enabled for the given console view.
      */
     fun isEnabled(consoleView: ConsoleView): Boolean {
-        return enabledMap[consoleView] ?: true
+        return enabledMap[consoleView] ?: true // default is true
     }
 
     /**
-     * Sets the enabled state for the given console view.
+     * Sets the enabled state of the formatting for the given console view.
      */
     fun setEnabled(consoleView: ConsoleView, value: Boolean) {
         enabledMap[consoleView] = value

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,4 +20,20 @@
         <listener class="io.github.orangain.prettyjsonlog.listeners.MyApplicationActivationListener"
                   topic="com.intellij.openapi.application.ApplicationActivationListener"/>
     </applicationListeners>
+
+    <actions>
+        <group id="prettyjsonlog.ConsoleContextMenuRoot">
+            <add-to-group group-id="ConsoleView.PopupMenu" anchor="first"/>
+
+            <group id="prettyjsonlog.ConsoleContextMenuGroup" popup="true" text="Pretty JSON Log">
+                <action
+                        id="prettyjsonlog.MyCustomAction"
+                        class="io.github.orangain.prettyjsonlog.action.ToggleEnabledAction"
+                        text="Formatting Enabled"
+                        description="Enable or disable formatting of JSON logs in the console">
+                </action>
+            </group>
+            <separator/>
+        </group>
+    </actions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,9 +28,7 @@
             <group id="io.github.orangain.prettyjsonlog.ConsoleContextMenuGroup" popup="true" text="Pretty JSON Log">
                 <action
                         id="io.github.orangain.prettyjsonlog.action.ToggleEnabledAction"
-                        class="io.github.orangain.prettyjsonlog.action.ToggleEnabledAction"
-                        text="Formatting Enabled"
-                        description="Enable or disable formatting of JSON logs in the console">
+                        class="io.github.orangain.prettyjsonlog.action.ToggleEnabledAction">
                 </action>
             </group>
             <separator/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,12 +22,12 @@
     </applicationListeners>
 
     <actions>
-        <group id="prettyjsonlog.ConsoleContextMenuRoot">
+        <group id="io.github.orangain.prettyjsonlog.ConsoleContextMenuRoot">
             <add-to-group group-id="ConsoleView.PopupMenu" anchor="first"/>
 
-            <group id="prettyjsonlog.ConsoleContextMenuGroup" popup="true" text="Pretty JSON Log">
+            <group id="io.github.orangain.prettyjsonlog.ConsoleContextMenuGroup" popup="true" text="Pretty JSON Log">
                 <action
-                        id="prettyjsonlog.MyCustomAction"
+                        id="io.github.orangain.prettyjsonlog.action.ToggleEnabledAction"
                         class="io.github.orangain.prettyjsonlog.action.ToggleEnabledAction"
                         text="Formatting Enabled"
                         description="Enable or disable formatting of JSON logs in the console">

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -1,1 +1,3 @@
 applicationActivated=Application activated
+action.io.github.orangain.prettyjsonlog.action.ToggleEnabledAction.text=Formatting Enabled
+action.io.github.orangain.prettyjsonlog.action.ToggleEnabledAction.description=Enable or disable formatting of JSON logs in the console


### PR DESCRIPTION
This allows users to temporarily disable JSON log formatting. This setting is temporary for each console view and is not stored anywhere. The formatting setting is enabled by default when a new console is created.


<img width="985" alt="image" src="https://github.com/user-attachments/assets/07db3bb3-7f49-4438-8e0c-0e16217389cd">


