### PR TITLE
StackdriverJsonLayout  timestampNanos timestampSeconds support

### DIFF
--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
@@ -62,7 +62,10 @@ fun extractTimestamp(node: JsonNode): Timestamp? {
         }
     }
     // Fallback to google GCP timestampSeconds and timestampNanos
+    return extractTimestampWithSecondsAndNanos(node)
+}
 
+fun extractTimestampWithSecondsAndNanos(node: JsonNode): Timestamp? {
     val timestampSeconds = node.get("timestampSeconds")?.asLong()
     val timestampNanos = node.get("timestampNanos")?.asLong()
     return if (timestampNanos != null && timestampSeconds != null) {
@@ -71,4 +74,3 @@ fun extractTimestamp(node: JsonNode): Timestamp? {
         null
     }
 }
-

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
@@ -49,7 +49,7 @@ sealed interface Timestamp {
     }
 }
 
-private val timestampKeys = listOf("timestamp", "time", "@timestamp", "ts", "@t", "Timestamp")
+private val timestampKeys = listOf("timestamp", "time", "@timestamp", "ts", "@t", "Timestamp", "timestampNanos")
 
 fun extractTimestamp(node: JsonNode): Timestamp? {
 

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
@@ -62,10 +62,7 @@ fun extractTimestamp(node: JsonNode): Timestamp? {
         }
     }
     // Fallback to google GCP timestampSeconds and timestampNanos
-    return extractTimestampWithSecondsAndNanos(node)
-}
 
-fun extractTimestampWithSecondsAndNanos(node: JsonNode): Timestamp? {
     val timestampSeconds = node.get("timestampSeconds")?.asLong()
     val timestampNanos = node.get("timestampNanos")?.asLong()
     return if (timestampNanos != null && timestampSeconds != null) {
@@ -74,3 +71,4 @@ fun extractTimestampWithSecondsAndNanos(node: JsonNode): Timestamp? {
         null
     }
 }
+

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
@@ -61,14 +61,4 @@ fun extractTimestamp(node: JsonNode): Timestamp? {
             Timestamp.fromString(timestampNode.asText())
         }
     }
-    // Fallback to google GCP timestampSeconds and timestampNanos
-
-    val timestampSeconds = node.get("timestampSeconds")?.asLong()
-    val timestampNanos = node.get("timestampNanos")?.asLong()
-    return if (timestampNanos != null && timestampSeconds != null) {
-        Timestamp.Parsed(Instant.ofEpochSecond(timestampSeconds, timestampNanos))
-    } else {
-        null
-    }
 }
-

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/logentry/Timestamp.kt
@@ -61,4 +61,14 @@ fun extractTimestamp(node: JsonNode): Timestamp? {
             Timestamp.fromString(timestampNode.asText())
         }
     }
+    // Fallback to google GCP timestampSeconds and timestampNanos
+
+    val timestampSeconds = node.get("timestampSeconds")?.asLong()
+    val timestampNanos = node.get("timestampNanos")?.asLong()
+    return if (timestampNanos != null && timestampSeconds != null) {
+        Timestamp.Parsed(Instant.ofEpochSecond(timestampSeconds, timestampNanos))
+    } else {
+        null
+    }
 }
+

--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/ExtractTest.kt
@@ -14,6 +14,15 @@ private data class ExtractParam(
 )
 
 private val params = listOf(
+    // https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/main/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/StackdriverJsonLayout.java
+    ExtractParam(
+        "Google Cloud Json Layout from com.google.cloud.spring.logging.StackdriverJsonLayout",
+        """{"context": "default","logger": "com.example.MyClass","message": "Hello, world!","severity": "INFO","thread": "main","timestampNanos": 69022000,"timestampSeconds": 1729071565}""",
+        Timestamp.Parsed(Instant.parse("2024-10-16T09:39:25.069022Z")),
+        Level.INFO,
+        "Hello, world!",
+        null,
+    ),
     // https://cloud.google.com/logging/docs/structured-logging
     ExtractParam(
         "Cloud Logging",

--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/TimestampTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/TimestampTest.kt
@@ -1,5 +1,7 @@
 package io.github.orangain.prettyjsonlog.logentry
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import junit.framework.TestCase
 import java.time.Instant
 
@@ -34,6 +36,20 @@ class TimestampTest : TestCase() {
         testCases.forEach { (input, expected) ->
             val actual = Timestamp.fromEpoch(input)
             assertEquals("Timestamp.fromEpoch($input)", Timestamp.Parsed(Instant.parse(expected)), actual)
+        }
+    }
+
+    fun testExtractGCPTimestampWithSecondsAndNanos() {
+        val testCases = listOf(
+            Pair(Instant.ofEpochSecond(1000, 500), """{"timestampSeconds": 1000, "timestampNanos": 500}"""),
+            Pair(Instant.ofEpochSecond(0, 0), """{"timestampSeconds": 0, "timestampNanos": 0}"""),
+            Pair(Instant.ofEpochSecond(1000000000, 123456789), """{"timestampSeconds": 1000000000, "timestampNanos": 123456789}""")
+        )
+        val objectMapper = ObjectMapper()
+        testCases.forEach { (expectedInstant, jsonString) ->
+            val jsonNode = objectMapper.readTree(jsonString) as ObjectNode
+            val actual = extractTimestampWithSecondsAndNanos(jsonNode)
+            assertEquals("extractTimestampWithSecondsAndNanos($jsonString)", Timestamp.Parsed(expectedInstant), actual)
         }
     }
 }

--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/TimestampTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/TimestampTest.kt
@@ -2,8 +2,6 @@ package io.github.orangain.prettyjsonlog.logentry
 
 import junit.framework.TestCase
 import java.time.Instant
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.ObjectNode
 
 private val testCases: List<Pair<Long, String>> = listOf(
     // seconds
@@ -36,20 +34,6 @@ class TimestampTest : TestCase() {
         testCases.forEach { (input, expected) ->
             val actual = Timestamp.fromEpoch(input)
             assertEquals("Timestamp.fromEpoch($input)", Timestamp.Parsed(Instant.parse(expected)), actual)
-        }
-    }
-
-    fun testExtractTimestampWithSecondsAndNanos() {
-        val testCases = listOf(
-            Pair(Instant.ofEpochSecond(1000, 500), """{"timestampSeconds": 1000, "timestampNanos": 500}"""),
-            Pair(Instant.ofEpochSecond(0, 0), """{"timestampSeconds": 0, "timestampNanos": 0}"""),
-            Pair(Instant.ofEpochSecond(1000000000, 123456789), """{"timestampSeconds": 1000000000, "timestampNanos": 123456789}""")
-        )
-
-        testCases.forEach { (expectedInstant, jsonString) ->
-            val jsonNode = objectMapper.readTree(jsonString) as ObjectNode
-            val actual = extractTimestampWithSecondsAndNanos(jsonNode)
-            assertEquals("extractTimestampWithSecondsAndNanos($jsonString)", Timestamp.Parsed(expectedInstant), actual)
         }
     }
 }

--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/TimestampTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/logentry/TimestampTest.kt
@@ -2,6 +2,8 @@ package io.github.orangain.prettyjsonlog.logentry
 
 import junit.framework.TestCase
 import java.time.Instant
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 
 private val testCases: List<Pair<Long, String>> = listOf(
     // seconds
@@ -34,6 +36,20 @@ class TimestampTest : TestCase() {
         testCases.forEach { (input, expected) ->
             val actual = Timestamp.fromEpoch(input)
             assertEquals("Timestamp.fromEpoch($input)", Timestamp.Parsed(Instant.parse(expected)), actual)
+        }
+    }
+
+    fun testExtractTimestampWithSecondsAndNanos() {
+        val testCases = listOf(
+            Pair(Instant.ofEpochSecond(1000, 500), """{"timestampSeconds": 1000, "timestampNanos": 500}"""),
+            Pair(Instant.ofEpochSecond(0, 0), """{"timestampSeconds": 0, "timestampNanos": 0}"""),
+            Pair(Instant.ofEpochSecond(1000000000, 123456789), """{"timestampSeconds": 1000000000, "timestampNanos": 123456789}""")
+        )
+
+        testCases.forEach { (expectedInstant, jsonString) ->
+            val jsonNode = objectMapper.readTree(jsonString) as ObjectNode
+            val actual = extractTimestampWithSecondsAndNanos(jsonNode)
+            assertEquals("extractTimestampWithSecondsAndNanos($jsonString)", Timestamp.Parsed(expectedInstant), actual)
         }
     }
 }


### PR DESCRIPTION
StackdriverJsonLayout in spring-cloud-gcp-logging writes a nano timestamp keyed by "timestampNanos".
Add "timestampNanos" to list of timestampKeys in Timestamp.kt 
to fix null appearing in Console  and fully support Google Cloud Logging console format with Logback.