### PR TITLE
Format JSON log lines larger than the console read buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Format JSON log lines longer than the IntelliJ console read buffer (~8 KB), which were previously printed unformatted because the IDE delivers them to the filter in multiple fragments
+
 ## [0.8.0] - 2026-02-21
 
 - Support for Logback JsonEncoder with formattedMessage, reported by @unkle-jb

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleInputFilterProvider.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/console/MyConsoleInputFilterProvider.kt
@@ -9,7 +9,9 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Pair
 import com.intellij.psi.search.GlobalSearchScope
-import io.github.orangain.prettyjsonlog.json.parseJson
+import com.fasterxml.jackson.databind.JsonNode
+import io.github.orangain.prettyjsonlog.json.LogLineReassembler
+import io.github.orangain.prettyjsonlog.json.ParseResult
 import io.github.orangain.prettyjsonlog.json.prettyPrintJson
 import io.github.orangain.prettyjsonlog.logentry.*
 import io.github.orangain.prettyjsonlog.service.EphemeralStateService
@@ -36,16 +38,34 @@ class MyConsoleInputFilter(
     private val consoleView: ConsoleView,
     private val project: Project
 ) : InputFilter {
+    // A single log line longer than the console read buffer (~8 KB) is delivered here in multiple
+    // fragments, so we reassemble it before parsing. See LogLineReassembler for details.
+    private val reassembler = LogLineReassembler()
+
     override fun applyFilter(
         text: String,
         contentType: ConsoleViewContentType
     ): MutableList<Pair<String, ConsoleViewContentType>>? {
         thisLogger().debug("contentType: $contentType, applyFilter: $text")
         if (!isEnabled()) {
+            // Flush any in-progress buffer so toggling formatting off never drops text.
+            reassembler.drain()?.let { return mutableListOf(Pair(it + text, contentType)) }
             return null
         }
-        val (node, suffixWhitespaces) = parseJson(text) ?: return null
 
+        return when (val result = reassembler.feed(text)) {
+            is ParseResult.Complete -> format(result.node, result.suffixWhitespaces, contentType)
+            is ParseResult.Passthrough -> mutableListOf(Pair(result.text, contentType))
+            ParseResult.Buffering -> mutableListOf() // Empty list suppresses this fragment until the line completes.
+            ParseResult.NotJson -> null
+        }
+    }
+
+    private fun format(
+        node: JsonNode,
+        suffixWhitespaces: String,
+        contentType: ConsoleViewContentType
+    ): MutableList<Pair<String, ConsoleViewContentType>> {
         val timestamp = extractTimestamp(node)
         val level = extractLevel(node)
         val message = extractMessage(node)

--- a/src/main/kotlin/io/github/orangain/prettyjsonlog/json/LogLineReassembler.kt
+++ b/src/main/kotlin/io/github/orangain/prettyjsonlog/json/LogLineReassembler.kt
@@ -1,0 +1,85 @@
+package io.github.orangain.prettyjsonlog.json
+
+import com.fasterxml.jackson.databind.JsonNode
+
+/**
+ * The outcome of feeding one console fragment to [LogLineReassembler].
+ */
+sealed interface ParseResult {
+    /** A complete JSON log line was parsed and should be formatted. */
+    data class Complete(val node: JsonNode, val suffixWhitespaces: String) : ParseResult
+
+    /** Buffering was given up (not JSON, or too large); emit this accumulated text verbatim. */
+    data class Passthrough(val text: String) : ParseResult
+
+    /** The fragment is part of a not-yet-complete JSON line; it should be suppressed for now. */
+    data object Buffering : ParseResult
+
+    /** The fragment is not JSON and was not buffered; leave it unchanged. */
+    data object NotJson : ParseResult
+}
+
+// IntelliJ's com.intellij.util.io.BaseOutputReader reads process output into a char[8192] buffer
+// and, with the default Options (splitToLines=true, sendIncompleteLines=true, withSeparators=true),
+// flushes an incomplete line after each read even when no newline has been seen yet. As a result, a
+// single log line longer than ~8192 chars is delivered to the console InputFilter in multiple
+// fragments. Only engage buffering for a fragment that plausibly is such a buffer-full split: it
+// does not terminate the line (no trailing newline), it is about as large as the platform read
+// buffer, and it starts like a JSON object.
+private const val SPLIT_THRESHOLD = 8000
+
+// Safety cap so that pathological non-JSON output starting with '{' and lacking newlines cannot grow
+// the buffer without bound.
+private const val MAX_BUFFER = 8 * 1024 * 1024 // 8 MiB
+
+/**
+ * Reassembles a single JSON log line that the IntelliJ console delivered as multiple fragments.
+ *
+ * One instance is held per console. Console output is flushed on a single thread per console, so the
+ * mutable [buffer] does not need synchronization.
+ */
+class LogLineReassembler {
+    private val buffer = StringBuilder()
+
+    fun feed(text: String): ParseResult {
+        if (buffer.isEmpty()) {
+            // Fast path: the common case where a whole line arrives in one fragment.
+            parseJson(text)?.let { (node, suffix) -> return ParseResult.Complete(node, suffix) }
+            return if (looksLikeSplitJsonStart(text)) {
+                buffer.append(text)
+                ParseResult.Buffering
+            } else {
+                ParseResult.NotJson
+            }
+        }
+
+        // Buffering in progress: append and try to complete the line.
+        buffer.append(text)
+        parseJson(buffer.toString())?.let { (node, suffix) ->
+            buffer.setLength(0)
+            return ParseResult.Complete(node, suffix)
+        }
+        if (text.endsWith("\n") || buffer.length > MAX_BUFFER) {
+            // The line ended (or overflowed the cap) but is not valid JSON. Give up and emit the
+            // accumulated text verbatim so that nothing previously suppressed is lost.
+            return ParseResult.Passthrough(drainBuffer())
+        }
+        return ParseResult.Buffering
+    }
+
+    /**
+     * Returns and clears any partially-buffered text, or null if nothing is buffered. Used to avoid
+     * losing suppressed fragments when formatting is toggled off mid-line.
+     */
+    fun drain(): String? = if (buffer.isEmpty()) null else drainBuffer()
+
+    private fun drainBuffer(): String {
+        val raw = buffer.toString()
+        buffer.setLength(0)
+        return raw
+    }
+}
+
+private fun looksLikeSplitJsonStart(text: String): Boolean {
+    return !text.endsWith("\n") && text.length >= SPLIT_THRESHOLD && text.trimStart().startsWith("{")
+}

--- a/src/test/kotlin/io/github/orangain/prettyjsonlog/json/LogLineReassemblerTest.kt
+++ b/src/test/kotlin/io/github/orangain/prettyjsonlog/json/LogLineReassemblerTest.kt
@@ -1,0 +1,86 @@
+package io.github.orangain.prettyjsonlog.json
+
+import junit.framework.TestCase
+
+class LogLineReassemblerTest : TestCase() {
+
+    private fun chunk(s: String, size: Int): List<String> =
+        s.chunked(size)
+
+    fun testCompleteLineInOneFragment() {
+        val reassembler = LogLineReassembler()
+        val result = reassembler.feed("""{"key": "value"}""" + "\n")
+        assertTrue(result is ParseResult.Complete)
+        result as ParseResult.Complete
+        assertEquals("""{"key":"value"}""", result.node.toString())
+        assertEquals("\n", result.suffixWhitespaces)
+    }
+
+    fun testLargeJsonSplitIntoFragmentsIsReassembled() {
+        // Build a single minified JSON line larger than the platform's 8192-char read buffer.
+        val sb = StringBuilder("""{"message":"start"""")
+        for (i in 0 until 2000) {
+            sb.append(""","field$i":"value$i"""")
+        }
+        sb.append("}")
+        val line = sb.toString() + "\n"
+        assertTrue("test line should exceed the 8 KB read buffer", line.length > 16384)
+
+        val fragments = chunk(line, 8192)
+        assertTrue("test should produce multiple fragments", fragments.size >= 2)
+
+        val reassembler = LogLineReassembler()
+        for (i in 0 until fragments.size - 1) {
+            assertEquals(
+                "fragment $i should be buffered, not emitted",
+                ParseResult.Buffering,
+                reassembler.feed(fragments[i])
+            )
+        }
+        val last = reassembler.feed(fragments.last())
+        assertTrue("last fragment should complete the line", last is ParseResult.Complete)
+        last as ParseResult.Complete
+
+        // Reassembled node must equal the node parsed from the whole line at once.
+        val whole = parseJson(line)!!
+        assertEquals(whole.first, last.node)
+        assertEquals(whole.second, last.suffixWhitespaces)
+    }
+
+    fun testLargeNonJsonIsPassedThroughWithoutLoss() {
+        val line = "{" + "x".repeat(20000) + "\n" // starts like JSON, but is not valid JSON
+        val fragments = chunk(line, 8192)
+
+        val reassembler = LogLineReassembler()
+        for (i in 0 until fragments.size - 1) {
+            assertEquals(ParseResult.Buffering, reassembler.feed(fragments[i]))
+        }
+        val last = reassembler.feed(fragments.last())
+        assertTrue("non-JSON line should be passed through", last is ParseResult.Passthrough)
+        last as ParseResult.Passthrough
+        // The whole original text must be preserved (nothing suppressed is lost).
+        assertEquals(line, last.text)
+    }
+
+    fun testShortNonJsonLineIsLeftUnchanged() {
+        val reassembler = LogLineReassembler()
+        assertEquals(ParseResult.NotJson, reassembler.feed("plain log message\n"))
+    }
+
+    fun testShortUnterminatedJsonStartIsNotBuffered() {
+        // Below the split threshold, an incomplete '{'-line is not buffered: it would only be
+        // split by the platform if it were ~8 KB, so we treat it as today (leave unchanged).
+        val reassembler = LogLineReassembler()
+        assertEquals(ParseResult.NotJson, reassembler.feed("""{"key": "value" """))
+    }
+
+    fun testDrainReturnsAndClearsBufferedText() {
+        val firstFragment = "{" + "x".repeat(9000) // > threshold, no newline -> buffered
+        val reassembler = LogLineReassembler()
+        assertEquals(ParseResult.Buffering, reassembler.feed(firstFragment))
+
+        assertEquals(firstFragment, reassembler.drain())
+        // After draining, the buffer is empty again.
+        assertNull(reassembler.drain())
+    }
+}


### PR DESCRIPTION
**DISCLAIMER:** Not exactly proud of it, but this PR was vibecoded entirely via Claude. I tested the changes locally, and it fixes my own issue regarding long log lines not formatting correctly, and doesn't seem to be causing any regressions elsewhere. I suspect it will also fix issues #49 and #139 

Feel free to review the changes, test them locally, suggest or make edits directly, or reject this altogether. AI generated description below:

---

IntelliJ's BaseOutputReader reads process output into a 8192-char buffer and, with the default Options (sendIncompleteLines=true), flushes an incomplete line after each read. So a single log line longer than ~8 KB is delivered to the console InputFilter in multiple fragments. The filter was stateless and required the whole text to be one complete JSON object, so large lines never matched and were printed unformatted.

Add LogLineReassembler to buffer split fragments until a complete JSON object can be parsed, then format it; non-JSON content is passed through verbatim so nothing is dropped. Wire it into MyConsoleInputFilter.